### PR TITLE
Fix 'multiple definitions of...' errors

### DIFF
--- a/src/VirtualFile.h
+++ b/src/VirtualFile.h
@@ -232,7 +232,7 @@ extern void *oslReadEntireFileToMemory(VIRTUAL_FILE *f, int *size);
 
 
 /*
-	Source par défaut: mémoire
+	Source par dï¿½faut: mï¿½moire
 */
 extern int vfsMemOpen(void *param1, int param2, int type, int mode, VIRTUAL_FILE* f);
 extern int vfsMemClose(VIRTUAL_FILE *f);
@@ -266,7 +266,7 @@ int oslInitVfsFile();
 	\param source
 		Can be VF_FILE, VF_MEMORY or any virtual file device registered by you.
 */
-extern inline void oslSetDefaultVirtualFileSource(int source)		{
+static inline void oslSetDefaultVirtualFileSource(int source)		{
 	osl_defaultVirtualFileSource = source;
 }
 
@@ -288,7 +288,7 @@ extern int VF_FILE;
 
 
 /** Gets the name of the temporary file. See #oslSetTempFileData for a code sample. */
-extern inline char *oslGetTempFileName()		{
+static inline char *oslGetTempFileName()		{
 	return (char*)osl_tempFileName;
 }
 

--- a/src/drawing.h
+++ b/src/drawing.h
@@ -162,7 +162,7 @@ black. You can get some nice effects once you've understood correctly what color
 extern void oslSetAlpha2(u32 effect, u32 coeff1, u32 coeff2);
 
 /** See oslSetAlpha2. */
-extern inline void oslSetAlpha(u32 effect, u32 coeff1)			{
+static inline void oslSetAlpha(u32 effect, u32 coeff1)			{
 	oslSetAlpha2(effect, coeff1, 0xffffffff);
 }
 
@@ -178,14 +178,14 @@ extern int osl_currentAlphaEffect;
 extern OSL_COLOR osl_currentAlphaCoeff, osl_currentAlphaCoeff2;
 
 /** Stores the current alpha parameters to an OSL_ALPHA_PARAMS structure. */
-extern inline void oslGetAlphaEx(OSL_ALPHA_PARAMS *alpha)		{
+static inline void oslGetAlphaEx(OSL_ALPHA_PARAMS *alpha)		{
 	alpha->effect = osl_currentAlphaEffect;
 	alpha->coeff1 = osl_currentAlphaCoeff;
 	alpha->coeff2 = osl_currentAlphaCoeff2;
 }
 
 /** Sets the current alpha parameters using an OSL_ALPHA_PARAMS structure. */
-extern inline void oslSetAlphaEx(OSL_ALPHA_PARAMS *alpha)		{
+static inline void oslSetAlphaEx(OSL_ALPHA_PARAMS *alpha)		{
 	oslSetAlpha2(alpha->effect, alpha->coeff1, alpha->coeff2);
 }
 
@@ -517,7 +517,7 @@ oslLoadImageFilePNG("test.png", OSL_IN_RAM | OSL_SWIZZLED, OSL_PF_5551);
 //Will swizzle if osl_autoSwizzleImages is set to true.
 oslLoadImageFilePNG("test.png", OSL_IN_RAM, OSL_PF_5551);
 \endcode */
-extern inline void oslSetImageAutoSwizzle(int enabled)		{
+static inline void oslSetImageAutoSwizzle(int enabled)		{
 	osl_autoSwizzleImages = enabled;
 }
 
@@ -839,7 +839,7 @@ That is, the following coordinates:
 \endcode
 
 \b Important: The maximum size of an image is 512x512! See considerations with #oslCreateImage. */
-extern inline void oslSetImageFrameSize(OSL_IMAGE *img, u16 width, u16 height)			{
+static inline void oslSetImageFrameSize(OSL_IMAGE *img, u16 width, u16 height)			{
 	img->frameSizeX = width, img->frameSizeY = height;
 }
 
@@ -935,7 +935,7 @@ oslUncachePalette(img->palette);
 extern OSL_PALETTE *oslCreatePaletteEx(int size, int location, short pixelFormat);
 
 /** Creates a palette. Simpler function without the \e location argument. */
-extern inline OSL_PALETTE *oslCreatePalette(int size, short pixelFormat)		{
+static inline OSL_PALETTE *oslCreatePalette(int size, short pixelFormat)		{
 	return oslCreatePaletteEx(size, OSL_IN_RAM, pixelFormat);
 }
 
@@ -965,7 +965,7 @@ extern void oslUncachePalette(OSL_PALETTE *pal);
 Never forget to call this after you've modified an image in a cached way (by default all the following routines do). See oslUncacheData for more information.
 
 Note: this routine does not flush the associated image palette data! Call oslUncacheImage instead if you need it! */
-extern inline void oslUncacheImageData(OSL_IMAGE *img)		{
+static inline void oslUncacheImageData(OSL_IMAGE *img)		{
     if (img != NULL)
         sceKernelDcacheWritebackInvalidateRange(img->data, img->totalSize);
 }
@@ -1248,7 +1248,7 @@ enum OSL_FX_ALPHATEST		{
 #define oslImageGetAutoStrip(img)				(img->flags & OSL_IMAGE_AUTOSTRIP)
 
 /** Defines if an image is a copy. For internal use only. */
-extern inline void oslImageIsCopySet(OSL_IMAGE *img, bool enabled)			{
+static inline void oslImageIsCopySet(OSL_IMAGE *img, bool enabled)			{
 	if (enabled)
 		img->flags |= OSL_IMAGE_COPY;
 	else
@@ -1256,7 +1256,7 @@ extern inline void oslImageIsCopySet(OSL_IMAGE *img, bool enabled)			{
 }
 
 /** Defines if an image is swizzled. For internal use only */
-extern inline void oslImageIsSwizzledSet(OSL_IMAGE *img, bool enabled)			{
+static inline void oslImageIsSwizzledSet(OSL_IMAGE *img, bool enabled)			{
 	if (enabled)
 		img->flags |= OSL_IMAGE_SWIZZLED;
 	else
@@ -1265,7 +1265,7 @@ extern inline void oslImageIsSwizzledSet(OSL_IMAGE *img, bool enabled)			{
 
 
 /** Defines if an image should be automatically stripped (divided in stripes to be blitted faster if it's very big). You shouldn't care about this. */
-extern inline void oslImageSetAutoStrip(OSL_IMAGE *img, bool enabled)			{
+static inline void oslImageSetAutoStrip(OSL_IMAGE *img, bool enabled)			{
 	if (enabled)
 		img->flags |= OSL_IMAGE_AUTOSTRIP;
 	else
@@ -1353,7 +1353,7 @@ left or the right will be either repeated or clamped depending on the parameter.
 		OSL_TW_CLAMP: Clamp (the same pixel is repeated indefinitely)
 		OSL_TW_REPEAT: The image texture is tiled.
 */
-extern inline void oslSetTextureWrap(int u, int v)		{
+static inline void oslSetTextureWrap(int u, int v)		{
 	sceGuTexWrap(u, v), osl_currentTexWrapU = u, osl_currentTexWrapV = v;
 }
 
@@ -1380,7 +1380,7 @@ extern void oslSetTexturePart(OSL_IMAGE *img, int x, int y);
 OSL_COLOR oslBlendColors(OSL_COLOR c1, OSL_COLOR c2);
 
 /** Applies the alpha parameters to a color, tinting it. This is needed as alpha is not applied to vertex color but only to textures. */
-extern inline OSL_COLOR oslBlendColor(OSL_COLOR c)		{
+static inline OSL_COLOR oslBlendColor(OSL_COLOR c)		{
 	return oslBlendColors(c, osl_currentAlphaCoeff);
 }
 

--- a/src/oslib.h
+++ b/src/oslib.h
@@ -219,7 +219,7 @@ extern int osl_quit;
 extern int osl_standByUnpermitted;
 extern int (*osl_powerCallback)(int, int, void*);
 extern int (*osl_exitCallback)(int, int, void*);
-extern int osl_vblInterruptNumber;									//Numéro de l'interruption VBLANK utilisée
+extern int osl_vblInterruptNumber;									//Numï¿½ro de l'interruption VBLANK utilisï¿½e
 
 //Don't access these
 extern int osl_maxFrameskip, osl_vsyncEnabled, osl_frameskip;
@@ -231,7 +231,7 @@ as arguments. */
 extern int oslSyncFrameEx(int frameskip, int max_frameskip, int vsync);
 
 /** Sets the framerate for oslSyncFrame(Ex). This can be any value from 1 to 60. For example, use 50 to simulate a PAL (european) game. */
-extern inline void oslSetFramerate(int framerate)		{
+static inline void oslSetFramerate(int framerate)		{
 	if (framerate <= 60)
 		osl_currentFrameRate = framerate;
 }
@@ -287,7 +287,7 @@ debug. */
 
 #ifdef PSP
 	/** Flushes the whole cache. This is slow, absolutely avoid it! Use oslUncacheData instead if possible. */
-	extern inline void oslFlushDataCache();
+	extern void oslFlushDataCache();
 #else
 	extern void oslFlushDataCache();
 #endif
@@ -378,7 +378,7 @@ oslPrintf("%i", oslNumberof(ram_files));
 
 /** Calculates the sine of an angle in degrees multiplicated by a radius. Returns the result as a float. oslSin and oslCos use the VFPU to compute the result, and thus it's very fast and very precise.
 	\param angle
-		Angle in degrees (360° means a full circle)
+		Angle in degrees (360ï¿½ means a full circle)
 	\param dist
 		Radius of the circle
 	\return
@@ -402,7 +402,7 @@ cY -= oslSin(cAngle, cSpeed);
 extern float oslSin(float angle, float dist);
 /** Calculates the cosine of an angle in degrees multiplicated by a radius. Returns the result as a float.
 	\param angle
-		Angle in degrees (360° means a full circle)
+		Angle in degrees (360ï¿½ means a full circle)
 	\param dist
 		Radius of the circle
 	\return
@@ -495,9 +495,9 @@ oslPrintf("Welcome...\n");
 */
 extern int oslBenchmarkTestEx(int startend, int slot);			//Permet de choisir un slot (0-3: user, 4:7: system)
 /** Same as oslBenchmarkTestEx but does a mean of 20 samples before returning a value. */
-extern int oslMeanBenchmarkTestEx(int startend, int slot);		//Benchmark système sur une moyenne de 20 échantillons
+extern int oslMeanBenchmarkTestEx(int startend, int slot);		//Benchmark systï¿½me sur une moyenne de 20 ï¿½chantillons
 /** Does a benchmark in the slot 0. Easier for testing. */
-extern inline int oslBenchmarkTest(int startend)		{
+static inline int oslBenchmarkTest(int startend)		{
 	return oslBenchmarkTestEx(startend, 0);
 }
 /** Displays the system benchmark results on the top-left corner of the screen. Useful for debugging: you know that if the first number approaches or exceeds 16.6 then your game has insufficient performance (for 60 fps). */
@@ -547,7 +547,7 @@ int main(void)
 
 	These files can be found in the Resource folder of your OSLib distribution.
 */
-extern inline int oslShowSplashScreen(int splashType)		{
+static inline int oslShowSplashScreen(int splashType)		{
 	if (splashType == 1)
 		return oslShowSplashScreen1();
 	else if (splashType == 2)
@@ -555,7 +555,7 @@ extern inline int oslShowSplashScreen(int splashType)		{
 	return 0;
 }
 
-extern inline int oslShowNeoflashLogo()		{
+static inline int oslShowNeoflashLogo()		{
 	return oslShowSplashScreen(2);
 }
 


### PR DESCRIPTION
Before this pull request, building a project (even the samples included in oslibmodv2) would produce errors such as:
```
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:969: multiple definition of `oslUncacheImageData'
bin/main.o:/usr/psp/include/oslib/drawing.h:969: first defined here
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:1252: multiple definition of `oslImageIsCopySet'
bin/main.o:/usr/psp/include/oslib/drawing.h:1252: first defined here
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:1260: multiple definition of `oslImageIsSwizzledSet'
bin/main.o:/usr/psp/include/oslib/drawing.h:1260: first defined here
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:1269: multiple definition of `oslImageSetAutoStrip'
bin/main.o:/usr/psp/include/oslib/drawing.h:1269: first defined here
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:1356: multiple definition of `oslSetTextureWrap'
bin/main.o:/usr/psp/include/oslib/drawing.h:1356: first defined here
/usr/lib/gcc/psp/9.3.0/../../../../psp/lib/libosl.a(oslGetImagePixel.o):/home/seeseemelk/.cache/yay/psp-oslib/src/oslibmodv2/src/drawing.h:1384: multiple definition of `oslBlendColor'
bin/main.o:/usr/psp/include/oslib/drawing.h:1384: first defined her
```

This PR fixes these errors by changing all `extern inline` functions to `static inline` in `oslib.h`, `display.h`, and `VirtualFile.h`.