### PR TITLE
Improve oslLoadImageFile function for better safety and extensibility

### DIFF
--- a/src/Special/oslLoadImageFile.c
+++ b/src/Special/oslLoadImageFile.c
@@ -1,27 +1,32 @@
 #include "../oslib.h"
 
-//Generic, includes support for all image types!
-OSL_IMAGE *oslLoadImageFile(char *filename, int location, int pixelFormat)
-{
-	char *ext, extension[10];
-	int i;
-	ext = strrchr(filename, '.');
-	if (!ext)
-		return NULL;
-	i = 0;
-	while(ext[i] && i < sizeof(extension) - 2)
-	{
-		extension[i] = tolower((unsigned char) ext[i]);
-		i++;
-	}
-	extension[i] = 0;
-	if (!strcmp(extension, ".png"))
-		return oslLoadImageFilePNG(filename, location, pixelFormat);
-	else if (!strcmp(extension, ".jpg"))
-		return oslLoadImageFileJPG(filename, location, pixelFormat);
-	else if (!strcmp(extension, ".gif"))
-		return oslLoadImageFileGIF(filename, location, pixelFormat);
+// Generic, includes support for all image types!
+OSL_IMAGE *oslLoadImageFile(char *filename, int location, int pixelFormat) {
+    if (!filename) {
+        return NULL;
+    }
 
-	return NULL;
+    const char *ext = strrchr(filename, '.');
+    if (!ext || ext == filename) {
+        return NULL;
+    }
+
+    char extension[10] = {0};
+    int i = 0;
+    while (ext[i] && i < sizeof(extension) - 1) // Leave space for the null terminator
+    {
+        extension[i] = tolower((unsigned char) ext[i]);
+        i++;
+    }
+
+    // Load the appropriate image type based on the extension
+    if (strcmp(extension, ".png") == 0) {
+        return oslLoadImageFilePNG(filename, location, pixelFormat);
+    } else if (strcmp(extension, ".jpg") == 0) {
+        return oslLoadImageFileJPG(filename, location, pixelFormat);
+    } else if (strcmp(extension, ".gif") == 0) {
+        return oslLoadImageFileGIF(filename, location, pixelFormat);
+    }
+
+    return NULL;
 }
-

--- a/src/Special/oslLoadImageFilePNG.c
+++ b/src/Special/oslLoadImageFilePNG.c
@@ -66,7 +66,7 @@ OSL_IMAGE *oslLoadImageFilePNG(char *filename, int location, int pixelFormat) {
 
     int wantedPixelFormat = pixelFormat;
 
-    // If we don't have a palette in the PNG but the pixel format requires one, 
+    // If we don't have a palette in the PNG but the pixel format requires one,
     // we load the image in 32-bit mode and convert it to paletted later with oslConvertImageTo.
     if (!num_palette && osl_pixelWidth[pixelFormat] <= 8) {
         pixelFormat = OSL_PF_8888;
@@ -87,7 +87,7 @@ OSL_IMAGE *oslLoadImageFilePNG(char *filename, int location, int pixelFormat) {
                     unsigned char g = palette[i].green;
                     unsigned char b = palette[i].blue;
                     unsigned char a = 0xff;
-                    //Color key?
+                    // Color key?
                     if (osl_colorKeyEnabled && RGBA(r, g, b, 0) == (osl_colorKeyValue & 0x00ffffff)) a = 0;
                     ((u32 *)img->palette->data)[i] = RGBA(r, g, b, a);
                 }


### PR DESCRIPTION
- Adjusted the loop condition to use `sizeof(extension) - 1` instead of `-2`, allowing the full extension to be copied while still ensuring space for a null terminator.
- Initialized the `extension` buffer with zeros, removing the need for manual null termination after the loop.
- Ensured the code handles edge cases such as the extension being at the start of the filename.