### PR TITLE
fix: Eliminate compiler warnings in image loaders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
-        "oslib.h": "c"
+        "oslib.h": "c",
+        "jpeglib.h": "c"
     },
     "C_Cpp.errorSquiggles": "disabled"
 }

--- a/src/image/format/oslLoadImageFileJPEG.c
+++ b/src/image/format/oslLoadImageFileJPEG.c
@@ -57,7 +57,7 @@ OSL_IMAGE *oslLoadImageFileJPG(char *filename, int location, int pixelFormat) {
 		row_pointer[0] = (unsigned char *)malloc(cinfo.output_width * cinfo.num_components);
 
 		if (row_pointer[0]) {
-			int x;
+			JDIMENSION x;
 			while (cinfo.output_scanline < cinfo.image_height) {
 				jpeg_read_scanlines(&cinfo, row_pointer, 1);
 				for (x = 0; x < cinfo.image_width; x++) {

--- a/src/image/format/oslLoadImageFilePNG.c
+++ b/src/image/format/oslLoadImageFilePNG.c
@@ -4,13 +4,18 @@
 #include <zlib.h>
 #include <zconf.h>
 
+// Forward declarations
+static void oslPngReadFn(png_structp png_ptr, png_bytep data, png_size_t length);
+static void oslPngFlushFn(png_structp png_ptr);
+
 // Read / Write PNG
-void oslPngReadFn(png_structp png_ptr, png_bytep data, png_size_t length) {
+static void oslPngReadFn(png_structp png_ptr, png_bytep data, png_size_t length) {
 	VIRTUAL_FILE *f = (VIRTUAL_FILE *)png_get_io_ptr(png_ptr);
 	VirtualFileRead(data, length, 1, f);
 }
 
-void oslPngFlushFn(png_structp png_ptr) {
+static void oslPngFlushFn(png_structp png_ptr) {
+	(void)png_ptr; // Suppress unused parameter warning
 	// No operation
 }
 
@@ -97,7 +102,7 @@ OSL_IMAGE *oslLoadImageFilePNG(char *filename, int location, int pixelFormat) {
 		u32 *p_dest4 = (u32 *)img->data;
 		u16 *p_dest2 = (u16 *)img->data;
 		u8 *p_dest1 = (u8 *)img->data;
-		int color_per_entry = 8 / depth;
+		size_t color_per_entry = 8 / depth;
 		int mask = (1 << depth) - 1;
 
 		for (u32 y = 0; y < height; ++y) {

--- a/src/image/oslLoadImageFile.c
+++ b/src/image/oslLoadImageFile.c
@@ -12,7 +12,7 @@ OSL_IMAGE *oslLoadImageFile(char *filename, int location, int pixelFormat) {
 	}
 
 	char extension[10] = {0};
-	int i = 0;
+	size_t i = 0;
 	while (i < sizeof(extension) - 1 && ext[i]) // Leave space for the null terminator
 	{
 		extension[i] = tolower((unsigned char) ext[i]);
@@ -21,15 +21,15 @@ OSL_IMAGE *oslLoadImageFile(char *filename, int location, int pixelFormat) {
 
 	// Load the appropriate image type based on the extension
 #ifdef OSL_IMAGE_LOADER_PNG
-    if (strcmp(extension, ".png") == 0)
+	if (strcmp(extension, ".png") == 0)
 		return oslLoadImageFilePNG(filename, location, pixelFormat);
 #endif
 #ifdef OSL_IMAGE_LOADER_JPEG
-    if (strcmp(extension, ".jpg") == 0)
+	if (strcmp(extension, ".jpg") == 0)
 		return oslLoadImageFileJPG(filename, location, pixelFormat);
 #endif
 #ifdef OSL_IMAGE_LOADER_GIF
-    if (strcmp(extension, ".gif") == 0)
+	if (strcmp(extension, ".gif") == 0)
 		return oslLoadImageFileGIF(filename, location, pixelFormat);
 #endif
 

--- a/src/image/oslWriteImageFile.c
+++ b/src/image/oslWriteImageFile.c
@@ -12,7 +12,7 @@ int oslWriteImageFile(OSL_IMAGE *img, const char* filename, int flags)
 		return 0;
 
 	char extension[10] = {0};
-	int i = 0;
+	size_t i = 0;
 	while (i < sizeof(extension) - 1 && ext[i]) // Leave space for the null terminator
 	{
 		extension[i] = tolower((unsigned char) ext[i]);


### PR DESCRIPTION
Resolves compiler warnings in image loading code:

- Use `size_t` for loop counters when comparing with `sizeof()`
- Use `JDIMENSION` type for JPEG image width comparisons  
- Mark PNG callback functions as `static` with forward declarations
- Suppress unused parameter warnings with `(void)` casts

**Warnings fixed:** `-Wsign-compare`, `-Wmissing-prototypes`, `-Wunused-parameter`

No functional changes.