### PR TITLE
feat: improve build system and suppress third-party warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ include_directories(
     src/adhoc
 )
 
+# Treat third-party library directories as system includes to suppress warnings
+include_directories(SYSTEM
+    ${PROJECT_SOURCE_DIR}/lib/giflib
+    ${PROJECT_SOURCE_DIR}/lib/libintraFont/include
+    ${PROJECT_SOURCE_DIR}/lib/libpspmath/include
+)
+
 # Define the source files
 set(SOURCE_DIR src)
 set(SFONT_SOURCES
@@ -145,6 +152,15 @@ include(${CMAKE_SYSTEM_CMAKE_PLATFORM_PATH}/IMG.cmake)
 
 # Specify that stub.S is an assembly file
 set_source_files_properties(${SOURCE_DIR}/stub.S PROPERTIES LANGUAGE ASM)
+
+# Suppress warnings for third-party library sources
+set_source_files_properties(
+    ${PSPMATH_SOURCES}
+    ${GIFLIB_SOURCES}
+    ${INTRAFONT_SOURCES}
+    PROPERTIES
+    COMPILE_FLAGS "-w"
+)
 
 # Add sources to the target
 target_sources(${TARGET_LIB} PRIVATE

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,9 @@ CFLAGS   := $(DEFINES) -O2 -G0 -ggdb -Wall -DHAVE_AV_CONFIG_H -fno-strict-aliasi
 CXXFLAGS := $(CFLAGS) -fno-exceptions -fno-rtti
 ASFLAGS  := $(CFLAGS)
 
+# Suppress warnings for third-party library sources
+CFLAGS_THIRD_PARTY := $(DEFINES) -O2 -G0 -ggdb -w -DHAVE_AV_CONFIG_H -fno-strict-aliasing -fverbose-asm
+
 LIBDIR   :=
 LDFLAGS  :=
 
@@ -277,3 +280,19 @@ ghpages: gendoc
 		git remote add remote https://x-access-token:$${GITHUB_TOKEN}@github.com/dogo/oslib.git && \
 		git push --force remote +master:gh-pages
 	rm -rf /tmp/ghpages
+
+#----------------------------------------------------------------------------
+#   Third-party library rules (suppress warnings)
+#   ---------------------------------------------
+
+# libpspmath objects
+$(PSPMATHOBJS): %.o: %.c
+	$(CC) $(CFLAGS_THIRD_PARTY) $(addprefix -I,$(INCDIR)) -c $< -o $@
+
+# giflib objects
+$(GIFLIBOBJS): %.o: %.c
+	$(CC) $(CFLAGS_THIRD_PARTY) $(addprefix -I,$(INCDIR)) -c $< -o $@
+
+# libintraFont objects
+$(INTRAFONTOBJS): %.o: %.c
+	$(CC) $(CFLAGS_THIRD_PARTY) $(addprefix -I,$(INCDIR)) -c $< -o $@

--- a/run-uncrustify.sh
+++ b/run-uncrustify.sh
@@ -26,7 +26,7 @@ for file in $files; do
 
     for pattern in "${ignored_patterns[@]}"; do
         # Remove trailing slashes and convert to relative path
-        rel_path="${file#${SCRIPT_DIR}/}"
+        rel_path="${file#"${SCRIPT_DIR}"/}"
 
         # Check if file matches pattern
         if [[ "$rel_path" == $pattern* ]] || [[ "$rel_path" == *"$pattern"* ]]; then


### PR DESCRIPTION
- Configure CMake and Makefile to suppress warnings from third-party libraries (giflib, libpspmath, libintraFont)
- Fix shellcheck warnings in run-uncrustify.sh script

Build output now only shows warnings from OSLib source code (src/),
making it easier to identify and fix project-specific issues.